### PR TITLE
Adding Appservices-perfscale org

### DIFF
--- a/public/organizations.json
+++ b/public/organizations.json
@@ -1,1 +1,1 @@
-["redhat-performance", "cloud-bulldozer", "arcalot", "perftool-incubator", "redhat-chaos", "distributed-system-analysis"]
+["redhat-performance", "cloud-bulldozer", "arcalot", "perftool-incubator", "redhat-chaos", "distributed-system-analysis", "Appservices-perfscale"]


### PR DESCRIPTION
Adding this one organization we are using for ConsoleDot related stuff.

Do we also care about about:

* private repos we use
* repos in orgs that are not ours (like "ansible")
* repos on internal gitlab instance

?